### PR TITLE
Changes for caravan device level LVS

### DIFF
--- a/flatten
+++ b/flatten
@@ -1,7 +1,7 @@
 *_nmos_m*
 *_pmos_m*
 *_cdns_*
-*_example_*
+*sky130_fd_pr__*_example_*
 *sky130_fd_pr__*[A-Z]*
 *sky130_ef_io__com*
 *sky130_ef_io__connect*

--- a/run_scheck
+++ b/run_scheck
@@ -88,7 +88,9 @@ else
 	sed -f remove_well.sed well/$TOP.gds.spice | \
 		awk -f remove_disconnect.awk - > well/$TOP.gds.nowell.spice ) &
 	# set link for lvs
-	ln -s well $TOP.ext
+	if [ ! -e $TOP.ext ]; then
+		ln -s well $TOP.ext
+	fi
 
 	export RUN_DIR=nowell
 	echo "Extracting layout without well in background process. See $RUN_DIR/$TOP.ext.gds.out."

--- a/simple_por.spice
+++ b/simple_por.spice
@@ -1,0 +1,53 @@
+.subckt simple_por vdd3v3 vss3v3 porb_h porb_l por_l vdd1v8 vss1v8
+*.iopin vdd3v3
+*.iopin vss3v3
+*.opin porb_h
+*.opin porb_l
+*.opin por_l
+*.iopin vdd1v8
+*.iopin vss1v8
+XC1 net9 vss3v3 sky130_fd_pr__cap_mim_m3_1 W=30 L=30 MF=1 m=1
+XC2 vss3v3 net9 sky130_fd_pr__cap_mim_m3_2 W=30 L=30 MF=1 m=1
+XM1 net3 net7 net5 vdd3v3 sky130_fd_pr__pfet_g5v0d10v5 L=0.8 W=2 nf=1 ad='int((nf+1)/2) * W/nf * 0.29'
++ as='int((nf+2)/2) * W/nf * 0.29' pd='2*int((nf+1)/2) * (W/nf + 0.29)' ps='2*int((nf+2)/2) * (W/nf + 0.29)'
++ nrd='0.29 / W' nrs='0.29 / W' sa=0 sb=0 sd=0 mult=1 m=1 
+XM2 net2 net3 vss3v3 vss3v3 sky130_fd_pr__nfet_g5v0d10v5 L=0.8 W=2 nf=1 ad='int((nf+1)/2) * W/nf * 0.29'
++ as='int((nf+2)/2) * W/nf * 0.29' pd='2*int((nf+1)/2) * (W/nf + 0.29)' ps='2*int((nf+2)/2) * (W/nf + 0.29)'
++ nrd='0.29 / W' nrs='0.29 / W' sa=0 sb=0 sd=0 mult=1 m=1 
+XR1 net4 vdd3v3 vss3v3 sky130_fd_pr__res_xhigh_po W=0.69 L=500 mult=1 m=1
+XM4 net5 net6 vdd3v3 vdd3v3 sky130_fd_pr__pfet_g5v0d10v5 L=0.8 W=2 nf=1 ad='int((nf+1)/2) * W/nf * 0.29'
++ as='int((nf+2)/2) * W/nf * 0.29' pd='2*int((nf+1)/2) * (W/nf + 0.29)' ps='2*int((nf+2)/2) * (W/nf + 0.29)'
++ nrd='0.29 / W' nrs='0.29 / W' sa=0 sb=0 sd=0 mult=1 m=1 
+XM5 net3 net3 vss3v3 vss3v3 sky130_fd_pr__nfet_g5v0d10v5 L=0.8 W=14 nf=7 ad='int((nf+1)/2) * W/nf * 0.29'
++ as='int((nf+2)/2) * W/nf * 0.29' pd='2*int((nf+1)/2) * (W/nf + 0.29)' ps='2*int((nf+2)/2) * (W/nf + 0.29)'
++ nrd='0.29 / W' nrs='0.29 / W' sa=0 sb=0 sd=0 mult=1 m=1 
+XR2 vss3v3 net4 vss3v3 sky130_fd_pr__res_xhigh_po W=0.69 L=150 mult=1 m=1
+XM7 net2 net2 net1 vdd3v3 sky130_fd_pr__pfet_g5v0d10v5 L=0.8 W=2 nf=1 ad='int((nf+1)/2) * W/nf * 0.29'
++ as='int((nf+2)/2) * W/nf * 0.29' pd='2*int((nf+1)/2) * (W/nf + 0.29)' ps='2*int((nf+2)/2) * (W/nf + 0.29)'
++ nrd='0.29 / W' nrs='0.29 / W' sa=0 sb=0 sd=0 mult=1 m=1 
+XM8 net1 net1 vdd3v3 vdd3v3 sky130_fd_pr__pfet_g5v0d10v5 L=0.8 W=14 nf=7 ad='int((nf+1)/2) * W/nf * 0.29'
++ as='int((nf+2)/2) * W/nf * 0.29' pd='2*int((nf+1)/2) * (W/nf + 0.29)' ps='2*int((nf+2)/2) * (W/nf + 0.29)'
++ nrd='0.29 / W' nrs='0.29 / W' sa=0 sb=0 sd=0 mult=1 m=1 
+XM10 net7 net4 vss3v3 vss3v3 sky130_fd_pr__nfet_g5v0d10v5 L=0.8 W=2 nf=1 ad='int((nf+1)/2) * W/nf * 0.29'
++ as='int((nf+2)/2) * W/nf * 0.29' pd='2*int((nf+1)/2) * (W/nf + 0.29)' ps='2*int((nf+2)/2) * (W/nf + 0.29)'
++ nrd='0.29 / W' nrs='0.29 / W' sa=0 sb=0 sd=0 mult=1 m=1 
+XM9 net7 net7 net6 vdd3v3 sky130_fd_pr__pfet_g5v0d10v5 L=0.8 W=2 nf=1 ad='int((nf+1)/2) * W/nf * 0.29'
++ as='int((nf+2)/2) * W/nf * 0.29' pd='2*int((nf+1)/2) * (W/nf + 0.29)' ps='2*int((nf+2)/2) * (W/nf + 0.29)'
++ nrd='0.29 / W' nrs='0.29 / W' sa=0 sb=0 sd=0 mult=1 m=1 
+XM11 net6 net6 vdd3v3 vdd3v3 sky130_fd_pr__pfet_g5v0d10v5 L=0.8 W=16 nf=8 ad='int((nf+1)/2) * W/nf * 0.29'
++ as='int((nf+2)/2) * W/nf * 0.29' pd='2*int((nf+1)/2) * (W/nf + 0.29)' ps='2*int((nf+2)/2) * (W/nf + 0.29)'
++ nrd='0.29 / W' nrs='0.29 / W' sa=0 sb=0 sd=0 mult=1 m=1 
+XM12 net8 net1 vdd3v3 vdd3v3 sky130_fd_pr__pfet_g5v0d10v5 L=0.8 W=2 nf=1 ad='int((nf+1)/2) * W/nf * 0.29'
++ as='int((nf+2)/2) * W/nf * 0.29' pd='2*int((nf+1)/2) * (W/nf + 0.29)' ps='2*int((nf+2)/2) * (W/nf + 0.29)'
++ nrd='0.29 / W' nrs='0.29 / W' sa=0 sb=0 sd=0 mult=1 m=1 
+XM13 net9 net2 net8 vdd3v3 sky130_fd_pr__pfet_g5v0d10v5 L=0.8 W=2 nf=1 ad='int((nf+1)/2) * W/nf * 0.29'
++ as='int((nf+2)/2) * W/nf * 0.29' pd='2*int((nf+1)/2) * (W/nf + 0.29)' ps='2*int((nf+2)/2) * (W/nf + 0.29)'
++ nrd='0.29 / W' nrs='0.29 / W' sa=0 sb=0 sd=0 mult=1 m=1 
+XR3 vss3v3 vss3v3 vss3v3 sky130_fd_pr__res_xhigh_po W=0.69 L=25 mult=2 m=2
+x2 net10 vss3v3 vss3v3 vdd3v3 vdd3v3 porb_h sky130_fd_sc_hvl__buf_8
+x3 net10 vss1v8 vss1v8 vdd1v8 vdd1v8 porb_l sky130_fd_sc_hvl__buf_8
+x4 net10 vss1v8 vss1v8 vdd1v8 vdd1v8 por_l sky130_fd_sc_hvl__inv_8
+x5 net9 vss3v3 vss3v3 vdd3v3 vdd3v3 net10 sky130_fd_sc_hvl__schmittbuf_1
+.ends
+** flattened .save nodes
+.end

--- a/spice_files
+++ b/spice_files
@@ -3,7 +3,11 @@ $::env(PDK_ROOT)/sky130A/libs.ref/sky130_fd_sc_hvl/spice/sky130_fd_sc_hvl.spice
 #$::env(PDK_ROOT)/sky130A/libs.ref/sky130_fd_io/spice/sky130_fd_io.spice
 #$::env(PDK_ROOT)/sky130A/libs.ref/sky130_fd_io/spice/sky130_ef_io.spice
 ./sky130_fd_io.spice
+$::env(PDK_ROOT)/sky130A/libs.ref/sky130_fd_io/spice/sky130_ef_io__analog_pad.spice
 ./sky130_ef_io.spice
 #$::env(PDK_ROOT)/sky130A/libs.ref/sky130_sram_macros/spice/sky130_sram_1kbyte_1rw1r_32x256_8.spice
 $::env(PDK_ROOT)/sky130A/libs.ref/sky130_sram_macros/spice/sky130_sram_2kbyte_1rw1r_32x512_8.spice
-../caravel/xschem/simple_por.spice
+#../caravel/xschem/simple_por.spice
+./simple_por.spice
+#../spi/lvs/user_analog_project_wrapper.spice
+./user_analog_project_wrapper.spice

--- a/verilog_files
+++ b/verilog_files
@@ -19,6 +19,7 @@
 ../verilog/gl/user_proj_example.v
 ../caravel/verilog/gl/caravel_clocking.v
 ../caravel/verilog/gl/chip_io.v
+../caravel/verilog/gl/chip_io_alt.v
 ../caravel/verilog/gl/digital_pll.v
 ../caravel/verilog/gl/gpio_control_block.v
 ../caravel/verilog/gl/gpio_logic_high.v


### PR DESCRIPTION
Flatten only primitives that contain ‘example’.
Create link to extraction directory only if it doesn’t exist.
Added local modified simple_por and user_analog_project_wrapper (sky130_fd_pr__res_xhigh_po_0p96 -> sky130_fd_pr__res_xhigh_po W=0.96).
Added sky130_ef_io__analog_pad spice reference.
Added chip_io_alt verilog reference.