### PR TITLE
Changes for abstract views

### DIFF
--- a/gds.spice.tcl
+++ b/gds.spice.tcl
@@ -10,6 +10,11 @@ puts "Flattening [gds flatglob]"
 gds flatten yes
 gds read $::env(CURRENT_GDS)
 
+foreach cell $::env(ABSTRACT_CELLS) {
+	load $cell -dereference
+	property LEFview true
+}
+
 load $::env(TOP) -dereference
 cd $::env(RUN_DIR)
 extract do local

--- a/run_caravel_lvs
+++ b/run_caravel_lvs
@@ -40,6 +40,8 @@ export TOP_LAYOUT=$3
 
 # Add any cells that should be flattened before extraction to 'flatten'. globbing allowed.
 export MAGIC_GDS_FLATTEN_CELLS="`cat flatten 2>/dev/null`"
+# Add any empty cells that should be extracted as black-boxes to 'abstract'.
+export ABSTRACT_CELLS="`cat abstract 2>/dev/null`"
 
 # Verify that magic and netgen are executable.
 if [ $# == 4 ]; then  # only if gds is specified

--- a/run_scheck
+++ b/run_scheck
@@ -38,6 +38,8 @@ export TOP=$1
 
 # Add any cells that should be flattened before extraction to 'flatten'. globbing allowed.
 export MAGIC_GDS_FLATTEN_CELLS="`cat flatten 2>/dev/null`"
+# Add any empty cells that should be extracted as black-boxes to 'abstract'.
+export ABSTRACT_CELLS="`cat abstract 2>/dev/null`"
 
 # Verify that magic and netgen are executable.
 which magic >& /dev/null


### PR DESCRIPTION
When a file `abstract` exists in the run directory, the cells listed in the file will be extracted as black boxes.